### PR TITLE
Add:Googleマップのピン表示

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,5 +1,5 @@
 class TopsController < ApplicationController
   def index
-    @google_places = GooglePlaces.all
+    @google_places = GooglePlace.all
   end
 end

--- a/app/models/google_place.rb
+++ b/app/models/google_place.rb
@@ -1,4 +1,4 @@
-class GooglePlaces
+class GooglePlace
   include ActiveModel::Model
   include ActiveModel::Attributes
 

--- a/app/models/google_places_api.rb
+++ b/app/models/google_places_api.rb
@@ -12,7 +12,7 @@ class GooglePlacesApi
       json = Net::HTTP.get(uri)
       data_list = JSON.parse(json, symbolize_names: true)
       data_list[:results].map do |data|
-        GooglePlaces.new(
+        GooglePlace.new(
           latitude: data.dig(:geometry, :location, :lat),
           longitude: data.dig(:geometry, :location, :lng),
           name: data[:name],

--- a/app/views/tops/_list.html.erb
+++ b/app/views/tops/_list.html.erb
@@ -1,6 +1,7 @@
 <table class="access-log-table table w-full">
   <thead>
     <tr>
+      <th>No.</th>
       <th>Name</th>
       <th>Rating</th>
       <th>Vicinity</th>
@@ -8,8 +9,9 @@
     </tr>
   </thead>
   <tbody>
-    <% google_places.each do |place| %>
+    <% google_places.each.with_index(1) do |place, i| %>
       <tr>
+        <td><%= i %></td>
         <td><%= place.name %></td>
         <td><%= place.rating %></td>
         <td><%= place.vicinity %></td>

--- a/app/views/tops/_map.html.erb
+++ b/app/views/tops/_map.html.erb
@@ -1,9 +1,0 @@
-<iframe
-  width="600"
-  height="450"
-  style="border:0"
-  loading="lazy"
-  allowfullscreen
-  referrerpolicy="no-referrer-when-downgrade"
-  src="https://www.google.com/maps/embed/v1/search?key=<%= Rails.application.credentials.google_map[:api_key] %>&q=長野 焼き鳥">
-</iframe>

--- a/app/views/tops/_map_sample.html.erb
+++ b/app/views/tops/_map_sample.html.erb
@@ -1,23 +1,49 @@
-<div id="map" class="h-full"></div>
-<script
-src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_map[:api_key] %>&callback=initMap&v=weekly"
-  defer
-  >
+<div id="map" class="h-96 w-full"></div>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_map[:api_key] %>&v=beta&libraries=marker&callback=initMap"></script>
+<script>
 
-function initMap() {
-  const myLatLng = { lat: -25.363, lng: 131.044 };
-  const map = new google.maps.Map(document.getElementById("map"), {
-    zoom: 4,
-    center: myLatLng,
-  });
+  let map;
+  let google_places = <%= google_places %>
 
-  new google.maps.Marker({
-    position: myLatLng,
-    map,
-    title: "Hello World!",
-  });
-}
+  function infoWnd(info) {
+    return new google.maps.InfoWindow({
+      content: info.attributes.name,
+      ariaLabel: info.attributes.name,
+    })
+  }
 
-window.initMap = initMap;
+  function initMap() {
+    map = new google.maps.Map(document.getElementById("map"), {
+      center: new google.maps.LatLng(36.64311, 138.18873),
+      zoom: 16,
+      mapId: '91eecefca61a0211'
+    });
+
+    for (let i = 0; i < google_places.length; i++) {
+      const index = String(i + 1)
+      const place = google_places[i]
+      const placeLatLng = { lat: place.attributes.latitude, lng: place.attributes.longitude }
+      const infowindow = infoWnd(place)
+      const pinView = new google.maps.marker.PinView({
+        background: "#FBBC04",
+        glyph: index,
+      });
+      
+      const marker = new google.maps.marker.AdvancedMarkerView({
+        map,
+        position: placeLatLng,
+        content: pinView.element,
+        title: place.attributes.name,
+      });
+
+      marker.addListener("click", () => {
+        infowindow.open({
+          anchor: marker,
+          map,
+        })
+      });
+    }
+  }
+
+  window.initMap = initMap;
 </script>
-

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,4 +1,3 @@
 <% set_meta_tags title: "" %>
-<%= render "tops/map" %>
-<%= render "tops/map_sample" %>
+<%= render partial: "tops/map_sample", locals: { google_places: @google_places.to_json.html_safe } %>
 <%= render partial: "tops/list", locals: { google_places: @google_places } %>


### PR DESCRIPTION
## 概要
- PlacesAPIを用いて取得したお店一覧に基づき、Googleマップ上にピンで表示するようにしました。
## 確認方法
- トップページにおいてGoogleMapが表示されていることを確認してください。
- お店一覧のインデックス番号とマップ上のピンに表示されている番号が一致していることを確認してください。
- ピンをクリックするとお店の名前がピンの上部にポップアップで表示されていることを確認してください。