### PR TITLE
Add:お店一覧の表示

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,5 +1,14 @@
 class TopsController < ApplicationController
-  def index; end
+  def index
+    params = {
+      v: 'beta',
+      libraries: 'marker,places',
+      callback: 'initMap'
+    }
+    query = URI.encode_www_form(params)
+    api_key = Rails.application.credentials.google_map[:api_key]
+    @uri = URI.parse("https://maps.googleapis.com/maps/api/js?key=#{api_key}&#{query}")
+  end
 
   def search
     @google_places = GooglePlace.search(params[:lat], params[:lng])

--- a/app/views/tops/_list.html.erb
+++ b/app/views/tops/_list.html.erb
@@ -1,12 +1,3 @@
-<table class="access-log-table table w-full">
-  <thead>
-    <tr>
-      <th>No.</th>
-      <th>Name</th>
-      <th>Rating</th>
-      <th>Vicinity</th>
-      <th>Opening Hours</th>
-    </tr>
-  </thead>
-  <tbody id='place-list'></tbody>
-</table>
+<div class="w-full my-4">
+  <div id='place-list'></div>
+</div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :js do %>
   <%= javascript_import_module_tag "tops/map" %>
 <% end %>
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_map[:api_key] %>&v=beta&libraries=marker&callback=initMap"></script>
+<script src="<%= @uri %>"></script>
 
 <% set_meta_tags title: "" %>
 <%= render partial: "tops/map" %>


### PR DESCRIPTION
## 概要
- お店の一覧表示をPlacesAPIを用いた方法から、GoogleMapJavaScriptAPIを用いた方法に変更しました。
- トップページにおけるお店の一覧表示のデザインを変更しました。
## 確認方法
- トップページにおいて現在地を取得できる場合はその周辺のお店を、取得できない場合は東京駅周辺のお店が一覧で表示されていることを確認してください。